### PR TITLE
Fixing deprecated function warning

### DIFF
--- a/woocommerce-memberships/frontend/use-legacy-members-area.php
+++ b/woocommerce-memberships/frontend/use-legacy-members-area.php
@@ -8,7 +8,8 @@ function sv_memberships_unhook_members_area() {
 	if ( ! is_admin() && function_exists( 'wc_memberships' ) ) {
 
 		$frontend     = wc_memberships()->get_frontend_instance();
-		$members_area = $frontend ? $frontend->get_members_area_instance() : null;
+ 		// $members_area = $frontend ? $frontend->get_members_area_instance() : null;
+		$members_area = $frontend ? $frontend->get_my_account_instance()->get_members_area_instance() : null;
 
 		if ( $members_area ) {
 			remove_filter( 'woocommerce_account_menu_items', array( $members_area, 'add_account_members_area_menu_item' ), 999 );


### PR DESCRIPTION
Code at Line 11 is generating following error:

> The WC_Memberships_Frontend::get_members_area_instance function is deprecated since version 1.19.0. Replace with WC_Memberships_Frontend::get_my_account_instance()->get_members_area_instance().

It can be fixed by replacing with the following code:
```
		$members_area = $frontend ? $frontend->get_my_account_instance()->get_members_area_instance() : null;
```