### PR TITLE
Update sort-documents-by-sku.php

### DIFF
--- a/woocommerce-print-invoices-packing-lists/sort-documents-by-sku.php
+++ b/woocommerce-print-invoices-packing-lists/sort-documents-by-sku.php
@@ -8,7 +8,7 @@
  * @param string $document_type        The type of document being viewed
  * @return string                      The filtered sort column key
  */
-function sv_wc_pip_document_sort_order_items_by_sku( $sort_by, $order_id, $type ) {
+function sv_wc_pip_document_sort_order_items_by_sku( $sort_by, $order_id, $document_type ) {
 
 	// uncomment if you want to only change the sort key for packing lists
 	// if ( 'packing-list' !== $document_type ) { return; }


### PR DESCRIPTION
change `$type` into `$document_type`

- The variable `$document_type` is declared in the DOC Block, but not used as input for the function. 
- The variable `$type` is declared in the input of the function but not used inside the function
- The variable `$document_type` is used in the function, but not provided as input of the function.

Changing variable `$type` into `$document_type` solves this issue